### PR TITLE
Upgrade to latest package versions, fix logic and add missing methods

### DIFF
--- a/HangFire.Azure.ServiceBusQueue.sln
+++ b/HangFire.Azure.ServiceBusQueue.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HangFire.Azure.ServiceBusQueue", "HangFire.Azure.ServiceBusQueue\HangFire.Azure.ServiceBusQueue.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Azure.ServiceBusQueue", "HangFire.Azure.ServiceBusQueue\Hangfire.Azure.ServiceBusQueue.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{756FFE84-4908-42BE-9918-4DA34E85AAFB}"
 	ProjectSection(SolutionItems) = preProject

--- a/HangFire.Azure.ServiceBusQueue/HangFire.Azure.ServiceBusQueue.csproj
+++ b/HangFire.Azure.ServiceBusQueue/HangFire.Azure.ServiceBusQueue.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>HangFire.Azure.ServiceBusQueue</RootNamespace>
-    <AssemblyName>HangFire.Azure.ServiceBusQueue</AssemblyName>
+    <RootNamespace>Hangfire.Azure.ServiceBusQueue</RootNamespace>
+    <AssemblyName>Hangfire.Azure.ServiceBusQueue</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -32,31 +32,35 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Hangfire.Core, Version=1.4.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HangFire.Core.1.4.5\lib\net45\Hangfire.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Dapper">
-      <HintPath>..\packages\Dapper.1.13\lib\net45\Dapper.dll</HintPath>
+    <Reference Include="Hangfire.SqlServer, Version=1.4.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HangFire.SqlServer.1.4.5\lib\net45\Hangfire.SqlServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="HangFire.Core">
-      <HintPath>..\packages\HangFire.Core.0.8.1\lib\net40\HangFire.Core.dll</HintPath>
+    <Reference Include="Microsoft.ServiceBus, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.ServiceBus.2.7.5\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="HangFire.SqlServer">
-      <HintPath>..\packages\HangFire.SqlServer.0.8.1\lib\net40\HangFire.SqlServer.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.2.3.2.0\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.2.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -67,8 +71,10 @@
     <Compile Include="ServiceBusQueueFetchedJob.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServiceBusQueueJobQueue.cs" />
+    <Compile Include="ServiceBusManager.cs" />
     <Compile Include="ServiceBusQueueJobQueueProvider.cs" />
     <Compile Include="ServiceBusQueueMonitoringApi.cs" />
+    <Compile Include="ServiceBusQueueOptions.cs" />
     <Compile Include="ServiceBusQueueSqlServerStorageExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/HangFire.Azure.ServiceBusQueue/ServiceBusManager.cs
+++ b/HangFire.Azure.ServiceBusQueue/ServiceBusManager.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Hangfire.Azure.ServiceBusQueue
+{
+    internal class ServiceBusManager
+    {
+        private readonly Dictionary<string, QueueClient> _clients;
+        private readonly ServiceBusQueueOptions _options;
+        private readonly NamespaceManager _namespaceManager;
+
+        public ServiceBusManager(ServiceBusQueueOptions options)
+        {
+            if (options == null) throw new ArgumentNullException("options");
+
+            _options = options;
+
+            _clients = new Dictionary<string, QueueClient>();
+            _namespaceManager = NamespaceManager.CreateFromConnectionString(options.ConnectionString);
+
+            CreateQueuesIfNotExists(_namespaceManager, options);
+        }
+
+        public QueueClient GetClient(string queue)
+        {
+            var prefixedQueue = _options.GetQueueName(queue);
+
+            QueueClient client;
+
+            if (!_clients.TryGetValue(prefixedQueue, out client))
+            {
+                client = QueueClient.CreateFromConnectionString(_options.ConnectionString, prefixedQueue, ReceiveMode.PeekLock);
+
+                _clients[prefixedQueue] = client;
+            }
+
+            return client;
+        }
+
+        public QueueDescription GetDescription(string queue)
+        {
+            return _namespaceManager.GetQueue(_options.GetQueueName(queue));
+        }
+
+        private static void CreateQueuesIfNotExists(NamespaceManager namespaceManager, ServiceBusQueueOptions options)
+        {
+            foreach (var queue in options.Queues)
+            {
+                var prefixed = options.GetQueueName(queue);
+
+                if (!namespaceManager.QueueExists(prefixed))
+                {
+                    var description = new QueueDescription(prefixed);
+
+                    if (options.Configure != null)
+                    {
+                        options.Configure(description);
+                    }
+
+                    namespaceManager.CreateQueue(description);
+                }
+            }
+        }
+    }
+}

--- a/HangFire.Azure.ServiceBusQueue/ServiceBusQueueFetchedJob.cs
+++ b/HangFire.Azure.ServiceBusQueue/ServiceBusQueueFetchedJob.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using HangFire.Storage;
+using Hangfire.Storage;
 using Microsoft.ServiceBus.Messaging;
 
-namespace HangFire.Azure.ServiceBusQueue
+namespace Hangfire.Azure.ServiceBusQueue
 {
     internal class ServiceBusQueueFetchedJob : IFetchedJob
     {
@@ -20,6 +20,12 @@ namespace HangFire.Azure.ServiceBusQueue
         }
 
         public string JobId { get; private set; }
+
+        public void Requeue()
+        {
+            _message.Abandon();
+            _completed = true;
+        }
 
         public void RemoveFromQueue()
         {

--- a/HangFire.Azure.ServiceBusQueue/ServiceBusQueueOptions.cs
+++ b/HangFire.Azure.ServiceBusQueue/ServiceBusQueueOptions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Hangfire.Azure.ServiceBusQueue
+{
+    public class ServiceBusQueueOptions
+    {
+        /// <summary>
+        /// Gets or sets the prefix that will be prepended to all queue names in
+        /// the service bus (e.g. if the prefix is "a-prefix-" then the default queue
+        /// will be named "a-prefix-default" in Azure)
+        /// </summary>
+        public string QueuePrefix { get; set; }
+
+        /// <summary>
+        /// Configures a queue on construction, for example setting maximum message
+        /// size of default TTL.
+        /// </summary>
+        public Action<QueueDescription> Configure { get; set; }
+
+        public string ConnectionString { get; set; }
+
+        public string[] Queues { get; set; }
+
+        internal string GetQueueName(string name)
+        {
+            if (QueuePrefix != null)
+            {
+                return QueuePrefix + name;
+            }
+
+            return name;
+        }
+
+        internal void Validate()
+        {
+            if (ConnectionString == null)
+                throw new InvalidOperationException("Must supply ConnectionString to ServiceBusQueueOptions");
+
+            if (Queues == null)
+                throw new InvalidOperationException("Must supply Queues to ServiceBusQueueOptions");
+
+            if (Queues.Length == 0)
+                throw new InvalidOperationException("Must supply at least one queue in Queues property of ServiceBusQueueOptions");
+        }
+    }
+}

--- a/HangFire.Azure.ServiceBusQueue/packages.config
+++ b/HangFire.Azure.ServiceBusQueue/packages.config
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
-  <package id="Dapper" version="1.13" targetFramework="net45" />
-  <package id="HangFire.Core" version="0.8.1" targetFramework="net45" />
-  <package id="HangFire.SqlServer" version="0.8.1" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.2.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
-  <package id="WindowsAzure.ServiceBus" version="2.3.2.0" targetFramework="net45" />
+  <package id="HangFire.Core" version="1.4.5" targetFramework="net45" />
+  <package id="HangFire.SqlServer" version="1.4.5" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="2.7.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request brings the code up to date with the latest 1.4x branch of Hangfire and fixes numerous issues present that stopped this from working.

I have not added tests at this time but have been testing it with our app and will be pushing it in to production soon.

Changes:
- Upgraded all package dependencies to their latest versions, including Hangfire
- Changed namespace from HangFire to Hangfire
- Introduce caching of the `QueueClient` because they can be expensive to create
- Add missing `Requeue` to ServiceBusFetchedJob
- Fixed enqueuing of a job by attaching to the `Completed` event of the surrounding transaction (otherwise an exception related to DTC is thrown)
- Added ability to specify a prefix for queues when created / used within the Azure Service Bus

Without knowing fully the internals of how this is used by SQL Storage I'm not sure if it is exactly correct or not, but from my testing it does seem to do what I would expect. A couple of concerns:
- `GetEnqueuedJobIds` ignores the `@from` parameter at the moment, as the previous code did.
- `GetFetchedJobIds` returns empty enumerable. Followed the pattern of existing Msmq / RabbitMq providers so assume this is OK?
- We have to enqueue outside of the transaction, which could cause issues should the sendng to the queue fail _after_ a job has been saved successfully. Is this scenario handled at all within Hangfire?
- `Dequeue` loops around each queue, waiting for the next message. If there are a number of queues could this lead to waiting longer than necessary should the first queues be empty but a subsequent one is not? This seems to be a common pattern in the other two providers.

What are your plans for maintaining this project going further as it's pretty much abandonware at the moment?
