### PR TITLE
Add support for Hangfire.SqlServer 1.7.0

### DIFF
--- a/nuspecs/Hangfire.Azure.ServiceBusQueue.nuspec
+++ b/nuspecs/Hangfire.Azure.ServiceBusQueue.nuspec
@@ -13,8 +13,8 @@
     <copyright>Copyright © 2015 Sergey Odinokov, Adam Barclay</copyright>
     <tags>Hangfire Azure ServiceBus SqlServer</tags>
 	<dependencies>
-		<dependency id="Hangfire.Core" version="1.5" />
-		<dependency id="Hangfire.SqlServer" version="1.5" />
+		<dependency id="Hangfire.Core" version="1.7.0" />
+		<dependency id="Hangfire.SqlServer" version="1.7.0" />
 		<dependency id="WindowsAzure.ServiceBus" version="2.7.5" />
 	</dependencies>
   </metadata>

--- a/src/HangFire.Azure.ServiceBusQueue/HangFire.Azure.ServiceBusQueue.csproj
+++ b/src/HangFire.Azure.ServiceBusQueue/HangFire.Azure.ServiceBusQueue.csproj
@@ -33,12 +33,12 @@
     <DocumentationFile>bin\Release\Hangfire.Azure.ServiceBusQueue.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hangfire.Core, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.Core.1.5.2\lib\net45\Hangfire.Core.dll</HintPath>
+    <Reference Include="Hangfire.Core, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.Core.1.7.0\lib\net45\Hangfire.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Hangfire.SqlServer, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.SqlServer.1.5.2\lib\net45\Hangfire.SqlServer.dll</HintPath>
+    <Reference Include="Hangfire.SqlServer, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.SqlServer.1.7.0\lib\net45\Hangfire.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueMonitoringApi.cs
+++ b/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueMonitoringApi.cs
@@ -24,10 +24,10 @@ namespace Hangfire.Azure.ServiceBusQueue
             return _queues;
         }
 
-        public IEnumerable<int> GetEnqueuedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetEnqueuedJobIds(string queue, int @from, int perPage)
         {
             var client = _manager.GetClient(queue);
-            var jobIds = new List<int>();
+            var jobIds = new List<long>();
 
             // We have to overfetch to retrieve enough messages for paging.
             // e.g. @from = 10 and page size = 20 we need 30 messages from the start
@@ -43,7 +43,7 @@ namespace Hangfire.Azure.ServiceBusQueue
                 // number
                 if (i >= @from)
                 {
-                    jobIds.Add(int.Parse(msg.GetBody<string>()));
+                    jobIds.Add(long.Parse(msg.GetBody<string>()));
                 }
 
                 msg.Dispose();
@@ -52,9 +52,9 @@ namespace Hangfire.Azure.ServiceBusQueue
             return jobIds;
         }
 
-        public IEnumerable<int> GetFetchedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetFetchedJobIds(string queue, int @from, int perPage)
         {
-            return Enumerable.Empty<int>();
+            return Enumerable.Empty<long>();
         }
 
         public EnqueuedAndFetchedCountDto GetEnqueuedAndFetchedCount(string queue)

--- a/src/HangFire.Azure.ServiceBusQueue/packages.config
+++ b/src/HangFire.Azure.ServiceBusQueue/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hangfire.Core" version="1.5.2" targetFramework="net45" />
-  <package id="Hangfire.SqlServer" version="1.5.2" targetFramework="net45" />
+  <package id="Hangfire.Core" version="1.7.0" targetFramework="net45" />
+  <package id="Hangfire.SqlServer" version="1.7.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/HangFire.Azure.ServiceBusQueue.Tests.csproj
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/HangFire.Azure.ServiceBusQueue.Tests.csproj
@@ -30,11 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hangfire.Core, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.Core.1.5.2\lib\net45\Hangfire.Core.dll</HintPath>
+    <Reference Include="Hangfire.Core, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.Core.1.7.0\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Hangfire.SqlServer, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.SqlServer.1.5.2\lib\net45\Hangfire.SqlServer.dll</HintPath>
+    <Reference Include="Hangfire.SqlServer, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.SqlServer.1.7.0\lib\net45\Hangfire.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\WindowsAzure.ServiceBus.2.7.5\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/ServiceBusQueueMonitoringApiFacts.cs
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/ServiceBusQueueMonitoringApiFacts.cs
@@ -91,7 +91,7 @@ namespace HangFire.Azure.ServiceBusQueue.Tests
             var counts = monitor.GetEnqueuedJobIds(options.Queues[0], 0, 5);
 
             // Assert/
-            Assert.That(counts, Is.EquivalentTo(new[] { 1, 2, 3, 4 }));
+            Assert.That(counts, Is.EquivalentTo(new long[] { 1, 2, 3, 4 }));
         }
 
         [Test]
@@ -108,8 +108,8 @@ namespace HangFire.Azure.ServiceBusQueue.Tests
             var counts2 = monitor.GetEnqueuedJobIds(options.Queues[0], 2, 2);
 
             // Assert/
-            Assert.That(counts1, Is.EquivalentTo(new[] { 1, 2 }));
-            Assert.That(counts2, Is.EquivalentTo(new[] { 3, 4 }));
+            Assert.That(counts1, Is.EquivalentTo(new long[] { 1, 2 }));
+            Assert.That(counts2, Is.EquivalentTo(new long[] { 3, 4 }));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace HangFire.Azure.ServiceBusQueue.Tests
             var counts = monitor.GetEnqueuedJobIds(options.Queues[0], 58, 2);
 
             // Assert/
-            Assert.That(counts, Is.EquivalentTo(new[] { 58, 59 }));
+            Assert.That(counts, Is.EquivalentTo(new long[] { 58, 59 }));
         }
     }
 }

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/packages.config
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hangfire.Core" version="1.5.2" targetFramework="net452" />
-  <package id="Hangfire.SqlServer" version="1.5.2" targetFramework="net452" />
+  <package id="Hangfire.Core" version="1.7.0" targetFramework="net452" />
+  <package id="Hangfire.SqlServer" version="1.7.0" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />


### PR DESCRIPTION
There was a breaking change in Hangfire.SqlServer 1.7.0 in `IPersistentJobQueueMonitoringApi` methods. `GetEnqueuedJobIds` and `GetFetchedJobIds` return type was changed to support `bigint` identifiers.

This PR adds support for new signatures, however it also requires a dependency version bump, that's again a breaking change. Should we also bump the version to 4.0.0 for these changes?

/cc @barclayadam 