### PR TITLE
Add the LockRenewalDelay option

### DIFF
--- a/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueFetchedJob.cs
+++ b/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueFetchedJob.cs
@@ -93,7 +93,7 @@ namespace Hangfire.Azure.ServiceBusQueue
                         catch (Exception ex)
                         {
                             _logger.DebugException(
-                                $"An exception was thrown while trying to renew a lock for job '{JobId}'.",
+                                String.Format("An exception was thrown while trying to renew a lock for job '{0}'.", JobId),
                                 ex);
                         }
                     }

--- a/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueJobQueue.cs
+++ b/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueJobQueue.cs
@@ -14,12 +14,15 @@ namespace Hangfire.Azure.ServiceBusQueue
         private static readonly TimeSpan MinSyncReceiveTimeout = TimeSpan.FromTicks(1);
 
         private readonly ServiceBusManager _manager;
+        private readonly ServiceBusQueueOptions _options;
 
-        public ServiceBusQueueJobQueue(ServiceBusManager manager)
+        public ServiceBusQueueJobQueue(ServiceBusManager manager, ServiceBusQueueOptions options)
         {
             if (manager == null) throw new ArgumentNullException("manager");
+            if (options == null) throw new ArgumentNullException("options");
 
             _manager = manager;
+            _options = options;
         }
 
         public IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken)
@@ -60,7 +63,7 @@ namespace Hangfire.Azure.ServiceBusQueue
                 queueIndex = (queueIndex + 1) % queues.Length;
             } while (message == null);
 
-            return new ServiceBusQueueFetchedJob(message);
+            return new ServiceBusQueueFetchedJob(message, _options.LockRenewalDelay);
         }
 
         public void Enqueue(IDbConnection connection, string queue, string jobId)

--- a/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueJobQueueProvider.cs
+++ b/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueJobQueueProvider.cs
@@ -25,7 +25,7 @@ namespace Hangfire.Azure.ServiceBusQueue
 
             var manager = new ServiceBusManager(options);
 
-            _jobQueue = new ServiceBusQueueJobQueue(manager);
+            _jobQueue = new ServiceBusQueueJobQueue(manager, options);
             _monitoringApi = new ServiceBusQueueMonitoringApi(manager, options.Queues);
         }
 

--- a/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueOptions.cs
+++ b/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueOptions.cs
@@ -35,6 +35,13 @@ namespace Hangfire.Azure.ServiceBusQueue
         /// requested.
         /// </remarks>
         public bool CheckAndCreateQueues { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a delay between calls to the <see cref="BrokeredMessage.RenewLock"/> method
+        /// to disallow workers to pick up the same background job several time while it's still
+        /// processing on an active server.
+        /// </summary>
+        public TimeSpan? LockRenewalDelay { get; set; }
 
         public string ConnectionString { get; set; }
 


### PR DESCRIPTION
This PR adds `ServiceBusQueueOptions.LockRenewalDelay` option that controls the delay between lock renewal commands are sent to ServiceBus, when background job is still processed by a worker. Previously lock renewal attempt was made just a second before the deadline, and we had the following problems.

* Delay was calculated as a difference between message's timestamp that was based on ServiceBus host time, and processing server's current time. So when time on those machines was non-synchronised (very likely scenario), we may send lock renewal query too late.
* We have only a single attempt to renew a lock. When that attempt fails even due to a transient error like network blip (we are in cloud, they happen constantly), lock renewal process is stopped, causing unwanted retry.

Instead, the new option allows us to send renewal queries with the configured delay. We can set it to 15 seconds, with lock timeout of 1 minute and have ~4 attempts to renew the lock even if there are transient errors.

This PR doesn't change the previous behaviour that will be used by default. The new behaviour is optional, and may be changed to the default one in future versions.