### PR TITLE
Update Azure.Messaging.ServiceBus, add TokenCredential option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ sqlStorage.UseServiceBusQueues(new ServiceBusQueueOptions
     {
         ConnectionString = connectionString,
 
-        Credential = new DefaultAzureCredential() // any Azure.Core.TokenCredential
+        Credential = new DefaultAzureCredential() // any Azure.Identity.TokenCredential
                 
         Configure = configureAction,
         

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,8 @@ sqlStorage.UseServiceBusQueues(connectionString, configureAction, "critical", "d
 sqlStorage.UseServiceBusQueues(new ServiceBusQueueOptions
     {
         ConnectionString = connectionString,
+
+        Credential = new DefaultAzureCredential() // any Azure.Core.TokenCredential
                 
         Configure = configureAction,
         

--- a/src/HangFire.Azure.ServiceBusQueue/HangFire.Azure.ServiceBusQueue.csproj
+++ b/src/HangFire.Azure.ServiceBusQueue/HangFire.Azure.ServiceBusQueue.csproj
@@ -17,7 +17,7 @@
         <Reference Include="System.Transactions" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.3.0" />
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
         <PackageReference Include="Hangfire.Core" Version="1.7.0" />
         <PackageReference Include="Hangfire.SqlServer" Version="1.7.0" />
     </ItemGroup>

--- a/src/HangFire.Azure.ServiceBusQueue/ServiceBusManager.cs
+++ b/src/HangFire.Azure.ServiceBusQueue/ServiceBusManager.cs
@@ -25,8 +25,8 @@ namespace Hangfire.Azure.ServiceBusQueue
 
             _senders               = new Dictionary<string, ServiceBusSender>(options.Queues.Length);
             _receivers             = new Dictionary<string, ServiceBusReceiver>(options.Queues.Length);
-            _managementClient      = new ServiceBusClient(options.ConnectionString);
-            _managementAdminClient = new ServiceBusAdministrationClient(options.ConnectionString);
+            _managementClient      = options.Credential != null ? new ServiceBusClient(options.ConnectionString, options.Credential) : new ServiceBusClient(options.ConnectionString);
+            _managementAdminClient = options.Credential != null ? new ServiceBusAdministrationClient(options.ConnectionString, options.Credential) : new ServiceBusAdministrationClient(options.ConnectionString);
 
             if (options.CheckAndCreateQueues)
             {

--- a/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueOptions.cs
+++ b/src/HangFire.Azure.ServiceBusQueue/ServiceBusQueueOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Azure.Core;
 
 namespace Hangfire.Azure.ServiceBusQueue
 {
@@ -56,6 +57,8 @@ namespace Hangfire.Azure.ServiceBusQueue
         public TimeSpan? LockRenewalDelay { get; set; }
 
         public string ConnectionString { get; set; }
+
+        public TokenCredential Credential { get; set; }
 
         public string[] Queues { get; set; }
 

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/HangFire.Azure.ServiceBusQueue.Tests.csproj
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/HangFire.Azure.ServiceBusQueue.Tests.csproj
@@ -6,6 +6,7 @@
     <Copyright>Copyright © Hangfire.Azure.ServiceBusQueue authors 2017</Copyright>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.13.1" />

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/ServiceBusQueueJobQueueFacts.cs
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/ServiceBusQueueJobQueueFacts.cs
@@ -27,7 +27,7 @@ namespace HangFire.Azure.ServiceBusQueue.Tests
         [TearDown]
         public async Task DeleteQueues()
         {
-            var manager = new ServiceBusAdministrationClient(options.ConnectionString);
+            var manager = options.Credential != null ? new ServiceBusAdministrationClient(options.ConnectionString, options.Credential) : new ServiceBusAdministrationClient(options.ConnectionString);
 
             foreach (var queueName in options.Queues)
             {

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/ServiceBusQueueMonitoringApiFacts.cs
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/ServiceBusQueueMonitoringApiFacts.cs
@@ -29,7 +29,7 @@ namespace HangFire.Azure.ServiceBusQueue.Tests
         [TearDown]
         public async Task DeleteQueues()
         {
-            var manager = new ServiceBusAdministrationClient(options.ConnectionString);
+            var manager = options.Credential != null ? new ServiceBusAdministrationClient(options.ConnectionString, options.Credential) : new ServiceBusAdministrationClient(options.ConnectionString);
 
             foreach (var currentQueue in options.Queues)
             {

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/TestServiceBusQueueOptions.cs
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/TestServiceBusQueueOptions.cs
@@ -16,7 +16,7 @@ namespace HangFire.Azure.ServiceBusQueue.Tests
 
             CheckAndCreateQueues = true;
             ConnectionString     = configBuilder["BusConnectionString"];
-            Credential           = new DefaultAzureCredential();
+            Credential           = configBuilder["UseDefaultAzureCredential"] == "true" ? new DefaultAzureCredential() : null;
             QueuePrefix          = "hf-sb-tests-";
             Queues               = new[] { "test1", "test2", "test3" };
             QueuePollInterval    = TimeSpan.Zero;

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/TestServiceBusQueueOptions.cs
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/TestServiceBusQueueOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using Hangfire.Azure.ServiceBusQueue;
 using Microsoft.Extensions.Configuration;
+using Azure.Identity;
 
 namespace HangFire.Azure.ServiceBusQueue.Tests
 {
@@ -15,6 +16,7 @@ namespace HangFire.Azure.ServiceBusQueue.Tests
 
             CheckAndCreateQueues = true;
             ConnectionString     = configBuilder["BusConnectionString"];
+            Credential           = new DefaultAzureCredential();
             QueuePrefix          = "hf-sb-tests-";
             Queues               = new[] { "test1", "test2", "test3" };
             QueuePollInterval    = TimeSpan.Zero;

--- a/tests/HangFire.Azure.ServiceBusQueue.Tests/appsettings.json
+++ b/tests/HangFire.Azure.ServiceBusQueue.Tests/appsettings.json
@@ -1,3 +1,4 @@
 ﻿{
-  "BusConnectionString": ""
+  "BusConnectionString": "",
+  "UseDefaultAzureCredential": "false"
 }


### PR DESCRIPTION
The current version of AMSB uses constructor overloads to configure TokenCredential and other passwordless credentials.  This adds the ability to pass a TokenCredential to the service bus clients and updates AMSB to the latest version.